### PR TITLE
Fixed date format

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func GetReview(config Config) (Reviews, error) {
 
 		dateNode := s.Find(REVIEW_DATE_CLASS_NAME)
 
-		date, err := time.Parse("2006年01月02日", dateNode.Text())
+		date, err := time.Parse("2006年1月2日", dateNode.Text())
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
1月2日とかがうまく取れてないようなので修正しました。
# パースできてないっぽい

```
2016/01/06 13:58:39 0001-01-01 00:00:00 +0000 UTC
```
# このプルリクで、パースできるようになる

```
2016/01/06 13:59:22 2016-01-03 00:00:00 +0000 UTC
```
